### PR TITLE
Skip build on docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,7 +79,7 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "conversa_openai_client"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "reqwest",
  "serde",

--- a/openai_client/Cargo.toml
+++ b/openai_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conversa_openai_client"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 authors = ["Joao Rebelo <jrebelo@s2e-systems.com>"]
 license = "Apache-2.0"

--- a/openai_client/build.rs
+++ b/openai_client/build.rs
@@ -1394,6 +1394,10 @@ fn parse_endpoint_path(path_schema: &Yaml, client_output_file: &mut File) {
 }
 
 fn main() {
+    if std::env::var("DOCS_RS").is_ok() {
+        return;
+    }
+
     println!("cargo::rerun-if-changed=./openapi.documented.yml");
     println!("cargo::rerun-if-changed=src/lib.rs");
 


### PR DESCRIPTION
Skip building the files when generating the docs since it is impossible to write on any folder outside the OUT_DIR which is causing an error at the moment.